### PR TITLE
Whitelist com.google.android.gms on doze

### DIFF
--- a/GmsCore/Android.mk
+++ b/GmsCore/Android.mk
@@ -9,6 +9,14 @@ LOCAL_SRC_FILES := $(LOCAL_MODULE)
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := whitelist-com.google.android.gms.xml
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/sysconfig
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := GmsCore
 LOCAL_SRC_FILES := com.google.android.gms-204714036.apk
@@ -17,6 +25,5 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 LOCAL_CERTIFICATE := PRESIGNED
 LOCAL_OVERRIDES_PACKAGES := com.qualcomm.location
-LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml
+LOCAL_REQUIRED_MODULES := privapp-permissions-com.google.android.gms.xml whitelist-com.google.android.gms.xml
 include $(BUILD_PREBUILT)
-

--- a/GmsCore/whitelist-com.google.android.gms.xml
+++ b/GmsCore/whitelist-com.google.android.gms.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2021 davze
+     SPDX-License-Identifer: GPL-3.0-or-later
+     This file contains whitelists for system functions to be granted by default.
+     Granting these permissions is necessary, e.g. power saving exception
+-->
+
+<!-- Allow to run microG GmsCore while in doze mode-->
+<config>
+    <allow-in-power-save package="com.google.android.gms" />
+</config>


### PR DESCRIPTION
Allow com.google.android.gms to be active while the device is dozing